### PR TITLE
feat: Switch to -moz-pref.

### DIFF
--- a/chrome.css
+++ b/chrome.css
@@ -2,7 +2,7 @@
     position: relative;
 }
 
-.tab-background[selected='']::after {
+.tab-background[selected]::after {
     content: '';
     position: absolute;
     top: 0px;
@@ -12,8 +12,8 @@
     background-color: var(--zen-primary-color);
 }
 
-@media (-moz-bool-pref: "theme.better-active-tab.on-right") {
-    .tab-background[selected='']::after {
+@media (-moz-pref("theme.better-active-tab.on-right")) {
+    .tab-background[selected]::after {
         left: unset; 
         right: 0px;
     }

--- a/preferences.json
+++ b/preferences.json
@@ -2,7 +2,7 @@
     {
         "property": "theme.better-active-tab.on-right",
         "label": "Move the active tab indicator to the right",
-        "type": "checkbox"
+        "type": "checkbox",
         "defaultValue": false
     }
 ]


### PR DESCRIPTION
The latest Zen Mods documentation for [checkbox preferences](https://docs.zen-browser.app/themes-store/themes-marketplace-preferences#checkbox-preferences) recommends using ```-moz-pref``` over ```-moz-bool-pref``` as the former is now natively implemented into Firefox and will be maintained, unlike the latter which was implemented by Zen exclusively and will not work anywhere else.

I also just simplified some of the queries and fixed the JSON syntax while I was at it and verified that all the code here worked properly before creating this pull request.

Thanks! :)